### PR TITLE
Remove Promisify dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,13 @@
 const jwt = require('jsonwebtoken');
-const promisify = require('util.promisify');
-const jwtVerify = promisify(jwt.verify);
+
+const jwtVerify = function(jwt_token, key, params) {
+  return new Promise((resolve, reject) => {
+      jwt.verify(jwt_token, key, params, (err, data) => {
+      if (err) reject(err)
+      else resolve(data);
+    });
+  })
+}
 
 async function VerifyJWT(jwks, jwt, audience, issuer) {
   var keys = jwks.keys

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "dependencies": {
-    "jsonwebtoken": "^8.4.0",
-    "util.promisify": "^1.0.0"
+    "jsonwebtoken": "^8.4.0"
   },
   "name": "cfaccessjwt",
   "version": "2.0.0",


### PR DESCRIPTION
This should remove the need for the Promisify dependency, makes the library a bit more self-contained.